### PR TITLE
Fixes #46, Changed the grid cross axis count and added an appbar

### DIFF
--- a/lib/fitDiet.dart
+++ b/lib/fitDiet.dart
@@ -26,17 +26,21 @@ class FitDiet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-        child: GridView.builder(
-            gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-              maxCrossAxisExtent: 200,
-              // mainAxisSpacing: 10,
-              // crossAxisSpacing: 10,
-            ),
-            itemCount: grid.length,
-            itemBuilder: (context, index) {
-              return GridContainer(
-                con: grid[index],
-              );
-            }));
+      child: Scaffold(
+          appBar: AppBar(
+            backgroundColor: Colors.black,
+            title: Text("Calorie Profiles"),
+          ),
+          body: GridView.builder(
+              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2,
+              ),
+              itemCount: grid.length,
+              itemBuilder: (context, index) {
+                return GridContainer(
+                  con: grid[index],
+                );
+              })),
+    );
   }
 }


### PR DESCRIPTION
Issue: 46

#### Short description of what this resolves:
It adds an appbar to the FitDiet screen
It changes the grid column count to 2
It removes the yellow error lines on "fit" text by adding a scaffold 



#### Changes proposed in this pull request and/or Screenshots of changes:

![Screenshot (174)](https://user-images.githubusercontent.com/62835310/212280535-f87dc166-d041-4876-a00a-a7b12806eac8.png)

